### PR TITLE
fix: update redis requirement according to https://pypi.org/project/redis/

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,8 @@
 #
 asgiref==3.5.0
     # via django
+deprecated==1.2.13
+    # via redis
 django==3.2.12
     # via
     #   django-lti-toolbox
@@ -16,7 +18,15 @@ huey==2.4.3
     # via lti-producer (setup.cfg)
 oauthlib==3.2.0
     # via django-lti-toolbox
+packaging==21.3
+    # via redis
+pyparsing==3.0.7
+    # via packaging
 pytz==2021.3
     # via django
+redis==4.1.4
+    # via lti-producer (setup.cfg)
 sqlparse==0.4.2
     # via django
+wrapt==1.13.3
+    # via deprecated

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,6 +24,8 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
+deprecated==1.2.13
+    # via redis
 django==3.2.12
     # via
     #   django-debug-toolbar
@@ -59,6 +61,8 @@ mypy-extensions==0.4.3
     #   mypy
 oauthlib==3.2.0
     # via django-lti-toolbox
+packaging==21.3
+    # via redis
 parso==0.8.3
     # via jedi
 pathspec==0.9.0
@@ -92,8 +96,12 @@ pylint-django==2.5.2
     # via lti-producer (setup.cfg)
 pylint-plugin-utils==0.7
     # via pylint-django
+pyparsing==3.0.7
+    # via packaging
 pytz==2021.3
     # via django
+redis==4.1.4
+    # via lti-producer (setup.cfg)
 six==1.16.0
     # via asttokens
 sqlparse==0.4.2
@@ -126,7 +134,9 @@ wcwidth==0.2.5
 wheel==0.37.1
     # via pip-tools
 wrapt==1.13.3
-    # via astroid
+    # via
+    #   astroid
+    #   deprecated
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     django
     django-lti-toolbox
     huey
-    redis-py
+    redis
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
According to installation instruction for `redis-py` module, installation must be performed using `redis` module name - https://pypi.org/project/redis/

This PR will fix this error:
```
# pip install -e git+https://github.com/strata-kk/lti-producer.git#egg=lti-producer
...
...
ERROR: Could not find a version that satisfies the requirement redis-py (from lti-producer)
ERROR: No matching distribution found for redis-py
```